### PR TITLE
Feature/runfunction

### DIFF
--- a/code_api/test/test_api.py
+++ b/code_api/test/test_api.py
@@ -315,3 +315,51 @@ class CodeAPITests(TestCase):
         self.assertEquals(data3_edit.status_code, 403)  # 所有者じゃないので編集できない
         self.assertEquals(data3_delete.status_code, 403)  # 所有者じゃないので削除できない
         self.assertEquals(data3_edit_Annonimous.status_code, 401)  # ログインユーザーでなく不正な操作である
+
+    def test_run_code(self):
+        """code/:id/runを実行し，実行結果を確認する．"""
+        # テストデータが足りないのでデータを追加
+        # ユーザ強制ログイン
+        self.client.force_authenticate(user=self.user1)
+
+        # データ準備
+        self.client.post(
+            "/codes/",
+            {
+                "code_content": "print('for run codes')",
+                "language": self.lang_python.id,
+                "step": self.step2.id,
+            },
+            format="json",
+        )
+        self.client.post(
+            "/codes/",
+            {
+                "code_content": "Alert('for run codes')",
+                "language": self.lang_javascript.id,
+                "step": self.step1.id,
+            },
+            format="json",
+        )
+        # ログアウト
+        self.client.logout()
+
+        # code/:id/runを実行
+        response1 = self.client.get(
+            f"/codes/{self.test_id1}/run/", {"p1": self.test_id2}
+        )
+        # レスポンスのステータスコードをチェック
+        self.assertEquals(response1.status_code, 200)
+        # jsonをデコード
+        body1 = json.loads(response1.content.decode("utf-8"))
+        # ID取得
+        result_id = body1["jsonId"]
+        # resultAPIからjsonを取得
+        response2 = self.client.get(f"/results/{result_id}/")
+        # レスポンスのステータスコードをチェック
+        self.assertEquals(response2.status_code, 200)
+        # jsonをデコード
+        body2 = json.loads(response2.content.decode("utf-8"))
+        # 指定したコードが入っているか確認
+        self.assertEquals(self.test_id1 in body2["codes"], True)
+        self.assertEquals(self.test_id2 in body2["codes"], True)

--- a/result_api/test/test_api.py
+++ b/result_api/test/test_api.py
@@ -193,6 +193,20 @@ class ResultAPITests(TestCase):
 
     def test_run_code_and_get_result(self):
         """code/:id/runを実行し，resultのjsonを取得する"""
+        # テストデータが足りないのでデータを追加
+        Code.objects.create(
+            code_content="print('for run code1')",
+            language=self.lang_python,
+            step=self.step1,
+            user=self.user,
+        )
+        Code.objects.create(
+            code_content="print('for run code2')",
+            language=self.lang_python,
+            step=self.step1,
+            user=self.user,
+        )
+
         # code/:id/runを実行
         response1 = self.client.get(f"/codes/{self.code1.id.urn[9:]}/run/")
         # レスポンスのステータスコードをチェック


### PR DESCRIPTION
実装内容
- シミュレーションの対戦相手をGETパラメータで指定できるようにCodeAPIのrunアクションを修正
- GETパラメータにはp1~p3まで指定できる（４人対戦を想定しているため，自分を除いた３人をGETパラメータで指定）
  - 例：/codes/$id/run/?p1=$otherid1&p2=$otherid2&p3=$otherid3
- 人数が足りない場合は，他のコードの中からランダムで選択
  - リクエストされたコードと同じステップのコードの中から選択